### PR TITLE
feat:  新增axios的 composition 寫法和 option 寫法的範例檔案

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -20,6 +20,12 @@ app.use(store)
 import i18n from './i18n'
 app.use(i18n)
 
+// axios
+import axios from 'axios'
+//app.config.globalProperties.$axios=axios
+//app.use(axios)
+app.provide('$axios', axios);
+
 // Initialize Firebase
 import { initializeApp } from 'firebase/app'
 import firebaseConfig from './config/firebaseConfig.js'

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -4,13 +4,21 @@ const router = createRouter({
   history: createWebHistory(),
   routes: [
     {
-      path: "/",
+      path: "/home",
       component: () => import("../views/Home.vue"),
     },
     {
       path: "/login",
       component: () => import("../views/Login.vue"),
     },
+    {
+      path: "/test_axios_option",
+      component: () => import("../views/Test_axios_option.vue")
+    },
+    {
+      path: "/test_axios_composition",
+      component: () => import("../views/Test_axios_comp.vue")
+    }
     // {
     //   path: "/register",
     //   component: () => import("../views/Register.vue"),

--- a/src/views/Test_axios_comp.vue
+++ b/src/views/Test_axios_comp.vue
@@ -1,0 +1,30 @@
+
+
+<template>
+    <el-container>
+        <el-header>
+            <el-affix>
+                <el-button type="primary" > Login </el-button>
+            </el-affix>
+        </el-header>
+        <el-main>
+            Welcome
+        </el-main>
+    </el-container>
+</template>
+
+
+<script setup>
+import { inject } from "vue";
+const $axios = inject('$axios');   // injecting in a component that wants it
+
+$axios.get('http://13.66.157.148:8080/api/getUserInformation')
+      .then((response) => {
+        let res = JSON.stringify(response.data); // 先 變字串
+        let resobj = JSON.parse(res) // 再變 object
+        console.log(resobj)
+      })
+  
+// $axios.get(...)
+
+</script>

--- a/src/views/Test_axios_option.vue
+++ b/src/views/Test_axios_option.vue
@@ -1,0 +1,28 @@
+
+
+<template>
+    <el-container>
+        <el-header>
+            <el-affix>
+                <el-button type="primary" > Login </el-button>
+            </el-affix>
+        </el-header>
+        <el-main>
+            Welcome
+        </el-main>
+    </el-container>
+</template>
+
+<script>
+export default{
+  inject: ['$axios'],
+  created(){
+    this.$axios.get('http://13.66.157.148:8080/api/getUserInformation')
+      .then((response) => {
+        let res = JSON.stringify(response.data); // 先 變字串
+        let resobj = JSON.parse(res) // 再變 object
+        console.log(resobj)
+      })
+  }
+}
+</script>


### PR DESCRIPTION
* main.js -> import axios 並使用 app.provide 讓composition 和 option api 都可以用

* router/index.js -> 新增兩個路徑
	1. /test_axios_option
	2. /test_axios_composition

* views/Test_axios_comp.vue -> axios composition api 用法

* views/Test_axios_option.vue -> axios option api 用法